### PR TITLE
Add a mode that allows edit without the picker

### DIFF
--- a/lua/nvim-tree/lib.lua
+++ b/lua/nvim-tree/lib.lua
@@ -337,7 +337,7 @@ function M.open_file(mode, filename)
   local win_ids = api.nvim_tabpage_list_wins(tabpage)
 
   local target_winid
-  if vim.g.nvim_tree_disable_window_picker == 1 then
+  if vim.g.nvim_tree_disable_window_picker == 1 or mode == "edit_no_picker" then
     target_winid = M.Tree.target_winid
   else
     target_winid = M.pick_window()


### PR DESCRIPTION
I would like to open new files in the most left window by default, but
have the option to select a specific window when needed. Currenlty the
window picking logic is either enabled or disabled, but adding this mode
allows different keybindings for both situations.

This allows me to choose to either open it in the default windows with a
single keypress (which is often my default behavior), or to open it with
the picker asking me where I want it to be opened.

Curious what you think of this. Name of the mode can of course be
changed to whatever you feel is a good name, but I would really like to
be able to use this functionality. Thanks!